### PR TITLE
Prompt when engine branches do not correspond to main application branch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-bundle (1.0.13)
+    git-bundle (1.0.14)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/git_bundle/console.rb
+++ b/lib/git_bundle/console.rb
@@ -23,6 +23,10 @@ module GitBundle
       puts colorize("\n=== #{repo.name} (#{repo.branch} ⇒ #{new_branch})", COLORS[:heading], true)
     end
 
+    def puts_diverged_repos(repos)
+      repos.each { |repo| puts colorize("  #{repo.name} (#{repo.branch})", COLORS[:prompt], true) }
+    end
+
     def puts_heading(text)
       puts colorize("\n=== #{text}", COLORS[:heading])
     end
@@ -88,6 +92,7 @@ module GitBundle
     end
 
     private
+
     def colorize(text, color_code, bold = false)
       if bold
         "\e[1m\e[#{color_code}m#{text}\e[0m"


### PR DESCRIPTION
This feature addresses the following common scenario:

1. A user create a new feature branch using `gitb checkout -b my-feature-branch`
2. The user then chooses to **only create a branch for engine A** (assume there are two engines, A and B).
3. While developing, the user makes changes to engine A **and B** (the user didn't initially think changes would be required for engine B as well, but the opposite turns out to be true). 
4. The user commits the changes for engine A and B.
5.  Since a branch wasn't created for engine B, those changes have now been committed to the original branch that engine B is still on (such as master). 
6. Without realising, **the user pushes these changes** using `gitb push`. 
7. Changes to engine B have now ended up in a branch that they weren't actually intended for. 

It's easy to miss this when pushing. This can lead to very unfortunate situations where in the best case scenario is that a rebase is required, and in a worst case scenario an entire application is brought down. 

This pull request introduces code that makes the user aware of such engines (where the branch doesn't correspond to the main application's branch) by prompting the user. The prompt is worded as follows:

```
=== engine-a (my-feature-branch)
639d143e Implement feature X

=== engine-b (master)
ea5d1233 Implement feature X

=== main-application (my-feature-branch)
12cf1873 Implement feature X

These repositories have changes and have diverged from the main application's branch (my-feature-branch)
  engine-b (master)

Do you want to continue? (Y/N)
```